### PR TITLE
New leaderlogs section using a new cncli docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@ First, lets create a docker volume in which to share the node.socket of the node
 
 ```
 docker volume create --name nodesocket
-
 ```
 
 Make sure running the block producer node with the following parameters (we add a docker volume and bind it with the node.socket folder in the node container)
@@ -227,7 +226,6 @@ docker run --detach \
     -v /mnt/disks/data01:/opt/cardano/data \
     -v nodesocket:/opt/cardano/ipc \
     nessusio/cardano-node run
-
 ```
 
 Wait for the block producer node to sync and start. Now let's start the cncli docker container. 
@@ -241,7 +239,6 @@ docker run -it -d \
     -v cardano-prod-config:/home/ubuntu/config \
     -e CARDANO_NODE_SOCKET_PATH=/opt/cardano/ipc/node.socket \
     jterrier84/cncli_arm64:4.0.1
-
 ```
 
 ### Slot Leader Schedule
@@ -253,21 +250,18 @@ We can now obtain the leader schedule for our pool for the current, next or prev
 
 ```
 docker exec -it cncli /home/ubuntu/cncli/scripts/cncli-leaderlog-current.sh [IP_RELAY] [PORT_RELAY] [POOL_ID]
-
 ```
 
 ###### Next
 
 ```
 docker exec -it cncli /home/ubuntu/cncli/scripts/cncli-leaderlog-next.sh [IP_RELAY] [PORT_RELAY] [POOL_ID]
-
 ```
 
 ###### Previous   
 
 ```
 docker exec -it cncli /home/ubuntu/cncli/scripts/cncli-leaderlog-previous.sh [IP_RELAY] [PORT_RELAY] [POOL_ID]
-
 ```
 
 The output will show something like this.
@@ -295,14 +289,12 @@ BCSH
 }
 `Epoch 301` 🧙🔮:
 `BCSH  - 0 `🎰`,  0% `🍀max, `0.09` 🧱ideal
-
 ```
 
 If desired, the cncli container can now be stopped. 
 
 ```
 docker stop cncli
-
 ```
 
 # Build the Images

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ For details you may want to have a look at [nix/docker/k8s/cardano-nodes.yaml](h
 
 For a Stake Pool Operator it is important to know when the node is scheduled to produce the next block. We definitely want to be online at that important moment and fullfil our block producing duties. There are better times to do node maintenance.
 
-This important functionality has also been built into the [jterrier84/cncli](https://hub.docker.com/repository/docker/jterrier84/cncli/general) image.
+This important functionality has also been built into the [jterrier84/cncli_arm64](https://hub.docker.com/repository/docker/jterrier84/cncli_arm64) image.
 
 First, lets create a docker volume in which to share the node.socket of the node container with the cncli container.
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ docker run --detach \
 
 ```
 
-Wait for the block producer node to sync and start. Now let's start the cncli docker container.
+Wait for the block producer node to sync and start. Now let's start the cncli docker container. 
+Note: If running on an amd64 architecture, replace "cncli_arm64" with "cncli_amd64".
 
 ```
 docker run -it -d \
@@ -239,7 +240,7 @@ docker run -it -d \
     -v /mnt/disks/data02:/home/ubuntu/db \
     -v cardano-prod-config:/home/ubuntu/config \
     -e CARDANO_NODE_SOCKET_PATH=/opt/cardano/ipc/node.socket \
-    jterrier84/cncli:latest bash
+    jterrier84/cncli_arm64:4.0.1
 
 ```
 
@@ -248,21 +249,21 @@ docker run -it -d \
 We can now obtain the leader schedule for our pool for the current, next or previous epoch. If executed the first time, the cncli database will be synced. This process might take some time (just be patient).
 
 
-## Current
+###### Current
 
 ```
 docker exec -it cncli /home/ubuntu/cncli/scripts/cncli-leaderlog-current.sh [IP_RELAY] [PORT_RELAY] [POOL_ID]
 
 ```
 
-## Next
+###### Next
 
 ```
 docker exec -it cncli /home/ubuntu/cncli/scripts/cncli-leaderlog-next.sh [IP_RELAY] [PORT_RELAY] [POOL_ID]
 
 ```
 
-## Previous   
+###### Previous   
 
 ```
 docker exec -it cncli /home/ubuntu/cncli/scripts/cncli-leaderlog-previous.sh [IP_RELAY] [PORT_RELAY] [POOL_ID]
@@ -294,6 +295,13 @@ BCSH
 }
 `Epoch 301` 🧙🔮:
 `BCSH  - 0 `🎰`,  0% `🍀max, `0.09` 🧱ideal
+
+```
+
+If desired, the cncli container can now be stopped. 
+
+```
+docker stop cncli
 
 ```
 

--- a/cncli/README.txt
+++ b/cncli/README.txt
@@ -1,0 +1,1 @@
+Prerequisites: Before start building the cncli docker image with build-cncli.sh, make sure to pull the nessusio/cardano-node on your host.

--- a/cncli/build-cncli.sh
+++ b/cncli/build-cncli.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -x
+
+docker build -t jterrier84/cncli \
+  -f cncli.dockerfile . \
+  2>&1 \
+  | tee /tmp/build-cncli.logs

--- a/cncli/cncli-fivedays.sh
+++ b/cncli/cncli-fivedays.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+CARDANO_START=$(date +%s -d "2017-09-23")
+CARDANO_START_DAY=$(( CARDANO_START / 86400 ))
+NOW_TIMESTAMP=$(date +%s)
+NOW_DAY=$(( NOW_TIMESTAMP / 86400 ))
+DAYS_SINCE_CARDANO_START=$(( NOW_DAY - CARDANO_START_DAY ))
+RESULT=$(( DAYS_SINCE_CARDANO_START % 5 ))
+
+if [[ "$RESULT" == "0" ]]; then
+    echo "Exit Success"
+    exit 0
+else
+    echo "Exit Failure"
+    exit 1
+fi

--- a/cncli/cncli-leaderlog-current.sh
+++ b/cncli/cncli-leaderlog-current.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+IP_NODE=$1
+PORT_NODE=$2
+POOL_ID=$3
+
+export CARDANO_NODE_SOCKET_PATH=/opt/cardano/ipc/node.socket
+
+/home/ubuntu/cncli/target/release/cncli sync --host $IP_NODE --port $PORT_NODE --db /home/ubuntu/db/cncli.db --no-service
+echo "BCSH"
+SNAPSHOT=$(/usr/bin/cardano-cli query stake-snapshot --stake-pool-id $POOL_ID --mainnet)
+POOL_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "poolStakeSet": )\d+(?=,?)')
+ACTIVE_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "activeStakeSet": )\d+(?=,?)')
+BCSH=`/home/ubuntu/cncli/target/release/cncli leaderlog --db /home/ubuntu/db/cncli.db --pool-id $POOL_ID --pool-vrf-skey /home/ubuntu/config/keys/pool/*.vrf.skey --byron-genesis /home/ubuntu/config/mainnet-byron-genesis.json --shelley-genesis /home/ubuntu/config/mainnet-shelley-genesis.json --pool-stake $POOL_STAKE --active-stake $ACTIVE_STAKE --ledger-set current`
+echo $BCSH | jq .
+
+EPOCH=`echo $BCSH | jq .epoch`
+echo "\`Epoch $EPOCH\` 🧙🔮:"
+
+SLOTS=`echo $BCSH | jq .epochSlots`
+IDEAL=`echo $BCSH | jq .epochSlotsIdeal`
+PERFORMANCE=`echo $BCSH | jq .maxPerformance`
+echo "\`BCSH  - $SLOTS \`🎰\`,  $PERFORMANCE% \`🍀max, \`$IDEAL\` 🧱ideal"

--- a/cncli/cncli-leaderlog-next.sh
+++ b/cncli/cncli-leaderlog-next.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+IP_NODE=$1
+NODE_PORT=$2
+POOL_ID=$3
+
+export CARDANO_NODE_SOCKET_PATH=/opt/cardano/ipc/node.socket
+
+/home/ubuntu/cncli/target/release/cncli sync --host $IP_NODE --port $NODE_PORT --db /home/ubuntu/db/cncli.db --no-service
+echo "BCSH"
+SNAPSHOT=$(/usr/bin/cardano-cli query stake-snapshot --stake-pool-id $POOL_ID --mainnet)
+POOL_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "poolStakeMark": )\d+(?=,?)')
+ACTIVE_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "activeStakeMark": )\d+(?=,?)')
+BCSH=`/home/ubuntu/cncli/target/release/cncli leaderlog --db /home/ubuntu/db/cncli.db --pool-id $POOL_ID --pool-vrf-skey /home/ubuntu/config/keys/pool/*.vrf.skey --byron-genesis /home/ubuntu/config/mainnet-byron-genesis.json --shelley-genesis /home/ubuntu/config/mainnet-shelley-genesis.json --pool-stake $POOL_STAKE --active-stake $ACTIVE_STAKE --ledger-set next`
+echo $BCSH | jq .
+
+EPOCH=`echo $BCSH | jq .epoch`
+echo "\`Epoch $EPOCH\` 🧙🔮:"
+
+SLOTS=`echo $BCSH | jq .epochSlots`
+IDEAL=`echo $BCSH | jq .epochSlotsIdeal`
+PERFORMANCE=`echo $BCSH | jq .maxPerformance`
+echo "\`BCSH  - $SLOTS \`🎰\`,  $PERFORMANCE% \`🍀max, \`$IDEAL\` 🧱ideal"

--- a/cncli/cncli-leaderlog-prev.sh
+++ b/cncli/cncli-leaderlog-prev.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+IP_NODE=$1
+NODE_PORT=$2
+POOL_ID=$3
+
+export CARDANO_NODE_SOCKET_PATH=/opt/cardano/ipc/node.socket
+
+/home/ubuntu/cncli/target/release/cncli sync --host $IP_NODE --port $NODE_PORT --db /home/ubuntu/db/cncli.db --no-service
+echo "BCSH"
+SNAPSHOT=$(/usr/bin/cardano-cli query stake-snapshot --stake-pool-id $POOL_ID --mainnet)
+POOL_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "poolStakeMark": )\d+(?=,?)')
+ACTIVE_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "activeStakeMark": )\d+(?=,?)')
+BCSH=`/home/ubuntu/cncli/target/release/cncli leaderlog --db /home/ubuntu/db/cncli.db --pool-id $POOL_ID --pool-vrf-skey /home/ubuntu/config/keys/pool/*.vrf.skey --byron-genesis /home/ubuntu/config/mainnet-byron-genesis.json --shelley-genesis /home/ubuntu/config/mainnet-shelley-genesis.json --pool-stake $POOL_STAKE --active-stake $ACTIVE_STAKE --ledger-set prev
+
+echo $BCSH | jq .
+
+EPOCH=`echo $BCSH | jq .epoch`
+echo "\`Epoch $EPOCH\` 🧙🔮:"
+
+SLOTS=`echo $BCSH | jq .epochSlots`
+IDEAL=`echo $BCSH | jq .epochSlotsIdeal`
+PERFORMANCE=`echo $BCSH | jq .maxPerformance`
+echo "\`BCSH  - $SLOTS \`🎰\`,  $PERFORMANCE% \`🍀max, \`$IDEAL\` 🧱ideal"

--- a/cncli/cncli-sendslots.sh
+++ b/cncli/cncli-sendslots.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+function getStatus() {
+    local result
+    result=$(/usr/local/bin/cncli status \
+        --db /root/scripts/cncli.db \
+        --byron-genesis /home/cardano-node/config/mainnet-byron-genesis.json \
+        --shelley-genesis /home/cardano-node/config/mainnet-shelley-genesis.json \
+        | jq -r .status
+    )
+    echo "$result"
+}
+
+function sendSlots() {
+    /usr/local/bin/cncli sendslots \
+        --db /root/scripts/cncli.db \
+        --byron-genesis /home/cardano-node/config/mainnet-byron-genesis.json \
+        --shelley-genesis /home/cardano-node/config/mainnet-shelley-genesis.json \
+        --config /root/scripts/pooltool.json
+}
+
+statusRet=$(getStatus)
+
+if [[ "$statusRet" == "ok" ]]; then
+    mv /root/scripts/sendslots.log /root/scripts/sendslots."$(date +%F-%H%M%S)".log
+    sendSlots > /root/scripts/sendslots.log
+    find . -name "sendslots.*.log" -mtime +15 -exec rm -f '{}' \;
+else
+    echo "CNCLI database not synced!!!"
+fi
+
+exit 0

--- a/cncli/cncli.dockerfile
+++ b/cncli/cncli.dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:20.04 as builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+
+RUN apt-get install -y \
+    build-essential \
+    curl
+
+#Install cncli
+RUN mkdir -p $HOME/.cargo/bin
+RUN chown -R $USER\: $HOME/.cargo
+RUN touch $HOME/.profile
+RUN chown $USER\: $HOME/.profile
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup install stable
+RUN rustup default stable
+RUN rustup update
+RUN rustup component add clippy rustfmt
+RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+RUN apt-get update -y && apt-get install -y automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 libtool autoconf
+RUN git clone --recurse-submodules https://github.com/AndrewWestberg/cncli && \
+    cd cncli && \
+    git checkout v4.0.1 && \
+    cargo install --path . --force
+
+FROM ubuntu:20.04
+
+RUN apt-get update
+
+RUN apt-get install -y \
+    --no-install-recommends \
+    jq
+
+WORKDIR /home/ubuntu
+WORKDIR /home/ubuntu/db
+WORKDIR /home/ubuntu/keys
+WORKDIR /home/ubuntu/config
+COPY --from=builder /cncli /home/ubuntu/cncli
+COPY --from=builder /lib /lib
+COPY --from=nessusio/cardano-node:1.30.1 /lib/lib* /lib/
+COPY --from=nessusio/cardano-node:1.30.1 /usr/local/bin/cardano-cli /usr/bin
+COPY --from=nessusio/cardano-node:1.30.1 /usr/local/bin/cardano-node /usr/bin
+COPY cncli-leaderlog-current.sh /home/ubuntu/cncli/scripts/
+COPY cncli-leaderlog-next.sh /home/ubuntu/cncli/scripts/
+ENV PATH="/home/ubuntu/cncli/target/release:${PATH}"
+
+ENTRYPOINT ["bash", "-c"]


### PR DESCRIPTION
**Reason for change:** The actual leaderlogs instruction and docker image does not work on arm64 platform. An issue was already created for this error.

**Description of change:** Complete new leaderlog section based on a new cncli docker image (https://hub.docker.com/u/jterrier84). The files for the docker image creation are saved in the new cncli repository.

**Note:**  Currently the docker image was build for arm64 only. A docker image for amd64 platform is still in progress. 
 

