### PR TITLE
Fetch topology nodes once before starting cardano

### DIFF
--- a/nix/docker/node/context/bin/run-node
+++ b/nix/docker/node/context/bin/run-node
@@ -334,6 +334,7 @@ printRunEnv
 writeRootEnv
 
 if [[ $CARDANO_UPDATE_TOPOLOGY == true ]]; then
+  topologyUpdate -p # Fetch topology nodes once before starting cardano
   topologyUpdate -l &
 fi
 


### PR DESCRIPTION
Since the topology files is not reread unless cardano is restarted I thought it would be useful to make a fetch request once before starting cardano. That way we can get fresh nodes on restart.