### PR TITLE
fix: fixed hardcoded namespace in POD_API_PATH 

### DIFF
--- a/nix/docker/node/context/bin/run-node
+++ b/nix/docker/node/context/bin/run-node
@@ -306,7 +306,7 @@ if [[ -z $CARDANO_PUBLIC_IP && -n $KUBERNETES_SERVICE_HOST ]]; then
 
     AUTH_HEADER="Authorization: Bearer ${TOKEN}"
 
-    POD_API_PATH="${APISERVER}/api/v1/namespaces/cardano/pods/${HOSTNAME}"
+    POD_API_PATH="${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}"
     NODE_NAME=$(curl -s --cacert ${CACERT} --header "${AUTH_HEADER}" -X GET ${POD_API_PATH} | jq -r ".spec.nodeName")
 
     if [[ -n ${NODE_NAME} ]]; then


### PR DESCRIPTION
If k8s namespace is not "cardano" and no env var CARDANO_PUBLIC_IP is provided, the container does not startup as a "jq" error is throw.
that's because POD_API_PATH has the hardcoded namespace "cardano" in it.
