### PR TITLE
Feat avoid cardano public ip curl calls in k8s if no topologyupdater running

### DIFF
--- a/nix/docker/node/context/bin/run-node
+++ b/nix/docker/node/context/bin/run-node
@@ -306,7 +306,7 @@ if [[ -z $CARDANO_PUBLIC_IP && -n $KUBERNETES_SERVICE_HOST ]]; then
 
     AUTH_HEADER="Authorization: Bearer ${TOKEN}"
 
-    POD_API_PATH="${APISERVER}/api/v1/namespaces/cardano/pods/${HOSTNAME}"
+    POD_API_PATH="${APISERVER}/api/v1/namespaces/${NAMESPACE}/pods/${HOSTNAME}"
     NODE_NAME=$(curl -s --cacert ${CACERT} --header "${AUTH_HEADER}" -X GET ${POD_API_PATH} | jq -r ".spec.nodeName")
 
     if [[ -n ${NODE_NAME} ]]; then

--- a/nix/docker/node/context/bin/run-node
+++ b/nix/docker/node/context/bin/run-node
@@ -288,8 +288,8 @@ mkdir -p `dirname $CARDANO_SOCKET_PATH`
 # Removing a potentialy existing lost+found directory
 rm -rf $CARDANO_DATABASE_PATH/lost+found
 
-# Find the public IP when we run on Kubernetes
-if [[ -z $CARDANO_PUBLIC_IP && -n $KUBERNETES_SERVICE_HOST ]]; then
+# Find the public IP when we run on Kubernetes and CARDANO_UPDATE_TOPOLOGY is true
+if [[ -z $CARDANO_PUBLIC_IP && -n $KUBERNETES_SERVICE_HOST && $CARDANO_UPDATE_TOPOLOGY == true ]]; then
 
   echo "Reading CARDANO_PUBLIC_IP from Kubernetes ..."
 


### PR DESCRIPTION
CARDANO_PUBLIC_IP is only needed for topologyupdater (CARDANO_UPDATE_TOPOLOGY = true).
no call to k8s api and serviceaccounts needed if CARDANO_UPDATE_TOPOLOGY = false). this prevents unnecessary calls to k8s api if CARDANO_UPDATE_TOPOLOGY = false.
