### PR TITLE
fix: always set CARDANO_NODE_SOCKET_PATH to CARDANO_SOCKET_PATH

### DIFF
--- a/nix/docker/node/context/bin/run-node
+++ b/nix/docker/node/context/bin/run-node
@@ -27,6 +27,8 @@ fi
 if [[ -z $CARDANO_SOCKET_PATH ]]; then
   CARDANO_SOCKET_PATH="/opt/cardano/ipc/node.socket"
 fi
+# always export CARDANO_NODE_SOCKET_PATH to make cardano-cli in local terminal working, even if a customized CARDANO_SOCKET_PATH was given:
+export CARDANO_NODE_SOCKET_PATH="$CARDANO_SOCKET_PATH"
 
 if [[ -z $CARDANO_LOG_DIR ]]; then
   CARDANO_LOG_DIR="/opt/cardano/logs"


### PR DESCRIPTION
cardano-cli is not working, if you start the container in node-mode with custom CARDANO_SOCKET_PATH.
we have to `export CARDANO_NODE_SOCKET_PATH="$CARDANO_SOCKET_PATH"` to make this work.

